### PR TITLE
autofix: resolve #7

### DIFF
--- a/website/src/components/Footer/Footer.tsx
+++ b/website/src/components/Footer/Footer.tsx
@@ -1,9 +1,10 @@
+import { Link } from 'react-router-dom';
 import './Footer.scss';
 
 const links = [
-  { label: '文档', href: '#docs' },
+  { label: '文档', to: '/docs' },
   { label: 'GitHub', href: 'https://github.com' },
-  { label: '更新日志', href: '#changelog' },
+  { label: '更新日志', to: '/changelog' },
 ];
 
 export default function Footer() {
@@ -19,15 +20,21 @@ export default function Footer() {
         
         <nav className="footer__links">
           {links.map((link) => (
-            <a 
-              key={link.label} 
-              href={link.href}
-              className="footer__link"
-              target={link.href.startsWith('http') ? '_blank' : undefined}
-              rel={link.href.startsWith('http') ? 'noopener noreferrer' : undefined}
-            >
-              {link.label}
-            </a>
+            'href' in link ? (
+              <a
+                key={link.label}
+                href={link.href}
+                className="footer__link"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {link.label}
+              </a>
+            ) : (
+              <Link key={link.label} to={link.to} className="footer__link">
+                {link.label}
+              </Link>
+            )
           ))}
         </nav>
       </div>


### PR DESCRIPTION
Fixes #7

## Summary

The bottom-right footer entry used hash anchors (`#docs`, `#changelog`) instead of app routes, so clicking it never reached the docs/changelog pages. This change switches internal footer navigation to `react-router-dom` `Link` components while keeping the external GitHub link unchanged.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`

Both commands completed successfully.

## Risk Notes

- Touches only `website/src/components/Footer/Footer.tsx`.
- Changes only internal footer navigation behavior.
- External link behavior remains unchanged.

## Disclosure

This pull request was generated by an automated issue-fix workflow for #7.